### PR TITLE
Fix deprecated use of ::set-output

### DIFF
--- a/.github/workflows/pr-autofix.yml
+++ b/.github/workflows/pr-autofix.yml
@@ -20,13 +20,13 @@ jobs:
 
           then
 
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
 
           exit 0
 
           fi
 
-          echo "::set-output name=changed::false"
+          echo "changed=false" >> $GITHUB_OUTPUT
 
           exit 0
       - run: yarn

--- a/lib/workflow-preprocessor.js
+++ b/lib/workflow-preprocessor.js
@@ -148,13 +148,13 @@ const compilePaths = (id /*:string*/, paths /*:Array<string>*/) /*: Step*/ => {
                     return `BASE=$\{GITHUB_BASE_REF:-HEAD~1}
 if [[ -n $(git diff --name-only refs/remotes/origin/$BASE --relative | grep '^${pattern}$') ]]
 then
-echo "::set-output name=changed::true"
+echo "changed=true" >> $GITHUB_OUTPUT
 exit 0
 fi`;
                 })
                 .join('\n\n') +
             `
-echo "::set-output name=changed::false"
+echo "changed=false" >> $GITHUB_OUTPUT
 exit 0`,
     };
 };


### PR DESCRIPTION
## Summary:

Github has deprecated use of ::set-state and ::set-output in Github Action workflows. The replacement is to echo key=value pairs to `$GITHUB_STATE` and `$GITHUB_OUTPUT`. 

Reference: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR fixes this repo to use the new syntax. We'll need to roll out a new version of these tools to all of our repos and then rebuild all workflows.

Issue: "none"

## Test plan: